### PR TITLE
Fixed crash if missing wired devices

### DIFF
--- a/tplink_archer_c9.py
+++ b/tplink_archer_c9.py
@@ -110,11 +110,12 @@ class TPLinkArcherC9Scanner(DeviceScanner):
                     'name': device['hostname']
                 }
 
-            for device in responseJson['data']['access_devices_wired']:
-                devices[device['ipaddr']] = {
-                    'ip': device['ipaddr'],
-                    'mac': device['macaddr'].upper(),
-                    'name': device['hostname']
-                }
+            if 'access_devices_wired' in responseJson['data']:
+              for device in responseJson['data']['access_devices_wired']:
+                  devices[device['ipaddr']] = {
+                      'ip': device['ipaddr'],
+                      'mac': device['macaddr'].upper(),
+                      'name': device['hostname']
+                  }
 
         return devices


### PR DESCRIPTION
First of all, thank you for providing this custom component, it worked perfectly for me.

I basically had only one issue, I don't have any wired devices connected (my RPi is connected via WiFi), so the platform initially crashed because of a missing key in the JSON response (the one containing wired devices).

This PR fixes this, I'm not sure if you're looking for PRs on this component or not, but I thought I'd give it a go.

In any case, thanks for making this available!